### PR TITLE
Convenience methods & docs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Run lint
       run: |
-        flake8 --format='::error file=%(path)s,line=%(row)d,col=%(col)d::%(text)s'
+        flake8 --format='::error file=%(path)s,line=%(row)d,col=%(col)d::%(code)s %(text)s'
 
   test:
     name: Test with Python ${{matrix.python}} on ${{matrix.platform}}

--- a/binpickle/__init__.py
+++ b/binpickle/__init__.py
@@ -4,5 +4,5 @@ Optimized format for pickling binary data.
 
 __version__ = '0.1'
 
-from .write import dump, BinPickler
-from .read import load, BinPickleFile
+from .write import dump, BinPickler    # noqa: F401
+from .read import load, BinPickleFile  # noqa: F401

--- a/binpickle/__init__.py
+++ b/binpickle/__init__.py
@@ -3,3 +3,6 @@ Optimized format for pickling binary data.
 """
 
 __version__ = '0.1'
+
+from .write import dump, BinPickler
+from .read import load, BinPickleFile

--- a/binpickle/read.py
+++ b/binpickle/read.py
@@ -130,3 +130,15 @@ class BinPickleFile:
         else:
             _log.debug('copying %d bytes from %d', length, start)
             return self._map[start:end]
+
+
+def load(file):
+    """
+    Load an object from a BinPickle file.
+
+    Args:
+        file(str or pathlib.Path): The file to load.
+    """
+
+    with BinPickleFile(file) as bpf:
+        return bpf.load()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,12 +12,33 @@ BinPickle supports a few useful features on top of standard pickling:
 * Optional per-buffer compression
 * Memory-mapped buffers (when uncompressed) for efficiently sharing
 
+BinPickle wraps Python's pickling functionality, so any object that can be pickled
+(including SciKit models) can be stored with BinPickle.  If the object supports
+Pickle Protocol 5 (or stores most of its data in NumPy arrays, which in recent
+versions support Pickle 5), then large array data will be efficiently stored,
+either compressed (with Blosc compression by default) or page-aligned and ready
+for memory-mapping, possibly into multiple processes simultaneously.
+
+Quick Start
+-----------
+
+Save an object::
+
+    from binpickle import dump, load
+    dump(my_large_object, 'file.bpk')
+
+Load an object::
+
+    model = load('file.bpk')
+
 Contents
 --------
 
 .. toctree::
    :maxdepth: 1
 
+   write
+   read
    codecs
    format
 

--- a/docs/read.rst
+++ b/docs/read.rst
@@ -1,0 +1,38 @@
+Reading BinPickle Files
+=======================
+
+Reading an object from a BinPickle file is done with :py:func:`load()`::
+
+    from binpickle import load
+    obj = load('file.bpk')
+
+The ``load`` Function
+---------------------
+
+.. autofunction:: binpickle.load
+
+The ``BinPickleFile`` Class
+---------------------------
+
+For full control of the deserialization process, and in particular to support
+memory-mapped object contents (e.g. for shared memory use), use
+:py:class:`binpickle.BinPickleFile` directly.
+
+If you open the BinPickle file in *direct* mode (the ``direct=True`` argument
+to :py:meth:`binpickle.BinPickleFile.__init__`), then the contents of buffers
+in the object (e.g. NumPy arrays or Pandas columns) will be directly backed by
+a read-only memory-mapped region from the BinPickle file.  This has two
+consequences:
+
+1.  Multiple processes with the same file open in direct mode will (usually)
+    *share* buffer memory.  This is one of BinPickle's particular benefits:
+    an easy way to load large array data, such as the learned parameters of
+    many SciKit-style machine learning models, in multiple processes with
+    minimal duplication.
+
+2.  The :py:class:`binpickle.BinPickleFile` object cannot be closed until
+    all objects referencing its memory have been destroyed.
+    :py:meth:`binpickle.BinPickleFile.close` will throw an exception if it
+    is closed prematurely.
+
+.. autoclass:: binpickle.BinPickleFile

--- a/docs/write.rst
+++ b/docs/write.rst
@@ -1,0 +1,21 @@
+Writing BinPickle Files
+=======================
+
+The easy, single-function entry point for saving data is :py:func:`binpickle.dump`::
+
+    from binpickle import dump
+    dump(obj, 'file.bpk')
+
+
+The ``dump`` Function
+---------------------
+
+.. autofunction:: binpickle.dump
+
+The ``BinPickler`` Class
+------------------------
+
+For full control over the serialization process, you can directly use the
+:py:class:`binpickle.BinPickler` backend class.
+
+.. autoclass:: binpickle.BinPickler

--- a/tests/test_rw.py
+++ b/tests/test_rw.py
@@ -131,7 +131,7 @@ def test_dump_frame(tmp_path, rng: np.random.Generator):
     })
 
     dump(df, file)
-    df2 = load(df, file)
+    df2 = load(file)
 
     assert all(df2.columns == df.columns)
     for c in df2.columns:

--- a/tests/test_rw.py
+++ b/tests/test_rw.py
@@ -9,8 +9,8 @@ from hypothesis import given, assume
 import hypothesis.strategies as st
 from hypothesis.extra.numpy import arrays, scalar_dtypes
 
-from binpickle.read import BinPickleFile
-from binpickle.write import BinPickler
+from binpickle.read import BinPickleFile, load
+from binpickle.write import BinPickler, dump
 
 RW_CONFIGS = it.product(
     [BinPickler, BinPickler.mappable, BinPickler.compressed],
@@ -118,6 +118,24 @@ def test_pickle_frame(tmp_path, rng: np.random.Generator, writer, direct):
         for c in df2.columns:
             assert all(df2[c] == df[c])
         del df2
+
+
+def test_dump_frame(tmp_path, rng: np.random.Generator):
+    "Pickle a Pandas data frame"
+    file = tmp_path / 'data.bpk'
+
+    df = pd.DataFrame({
+        'key': np.arange(0, 5000),
+        'count': rng.integers(0, 1000, 5000),
+        'score': rng.normal(10, 2, 5000)
+    })
+
+    dump(df, file)
+    df2 = load(df, file)
+
+    assert all(df2.columns == df.columns)
+    for c in df2.columns:
+        assert all(df2[c] == df[c])
 
 
 @given(arrays(scalar_dtypes(), st.integers(500, 10000)))


### PR DESCRIPTION
Make it much easier to get started with BinPickle:

- Add `dump` and `load` convenience methods, and re-export top-level objects (closes #1)
- Provide quickstart material in the docs (closes #2)