### PR TITLE
Clean up resource usage

### DIFF
--- a/binpickle/read.py
+++ b/binpickle/read.py
@@ -28,10 +28,10 @@ class BinPickleFile:
     def __init__(self, filename, *, direct=False):
         self.filename = filename
         self.direct = direct
-        self._file = open(filename, 'rb')
-        self.header = FileHeader.read(self._file)
-        self._map = mmap.mmap(self._file.fileno(), self.header.length,
-                              access=mmap.ACCESS_READ)
+        with open(filename, 'rb') as bpf:
+            self.header = FileHeader.read(bpf)
+            self._map = mmap.mmap(bpf.fileno(), self.header.length,
+                                  access=mmap.ACCESS_READ)
         self._mv = memoryview(self._map)
         self._read_index()
 
@@ -93,7 +93,6 @@ class BinPickleFile:
         del self._index_buf
         del self._mv
         self._map.close()
-        self._file.close()
 
     def _read_index(self):
         tpos = self.header.trailer_pos()

--- a/binpickle/write.py
+++ b/binpickle/write.py
@@ -137,6 +137,8 @@ class BinPickler:
         _log.debug('writing %d bytes at position %d', length, offset)
         cko = CKOut(self._file)
         c_spec = self._encode_buffer(buf, cko)
+        _log.debug('encoded %d bytes to %d (%.2f%% saved)', length, cko.bytes,
+                   (length - cko.bytes) / length * 100 if length else -0.0)
 
         assert self._file.tell() == offset + cko.bytes
 


### PR DESCRIPTION
This cleans up some resource usage (closing a file faster), and adds more useful logging to BinPickle creation.