### PR TITLE
Update Copier & use setuptools + adopt SPEC0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 7f2b85a
+_commit: 0e64af4
 _src_path: https://github.com/lenskit/lk-project-template
 package_name: binpickle
 project_descr: Optimized format for pickling binary data.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,9 @@
 # Changes here will be overwritten by Copier
-_commit: b99ad71
+_commit: 7f2b85a
 _src_path: https://github.com/lenskit/lk-project-template
 package_name: binpickle
+project_descr: Optimized format for pickling binary data.
 project_name: binpickle
+project_title: BinPickle
 require_lint: true
 start_year: 2020

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
         - windows
         - ubuntu
         python:
-        - "3.8"
-        - "3.9"
         - "3.10"
         - "3.11"
         exclude:
@@ -64,7 +62,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.10"
 
     - name: Set up dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,7 @@ jobs:
 
     - name: Set up dependencies
       run: |
-        pip install -U 'flit>=3.8'
-        flit install --only-deps --deps=all
+        pip install -e '.[blosc,numcodecs,test]'
 
     - name: Run tests
       run: python -m pytest --cov=binpickle --cov-report=xml tests
@@ -69,8 +68,7 @@ jobs:
 
     - name: Set up dependencies
       run: |
-        pip install -U 'flit>=3.8'
-        flit install --only-deps --deps=production --extras test
+        pip install -e '.[test]'
 
     - name: Run tests
       run: python -m pytest --cov=binpickle --cov-report=xml tests
@@ -112,10 +110,10 @@ jobs:
         python-version: "3.10"
 
     - name: Install Python deps
-      run: pip install -U flit
+      run: pip install -U build
 
     - name: Build distribution
-      run: flit build
+      run: python -m build
 
     - name: Save archive
       uses: actions/upload-artifact@v1
@@ -129,9 +127,9 @@ jobs:
     - name: Publish PyPI packages
       if: github.event_name == 'release'
       run: |
-        flit publish
+        twine upload dist/*
       shell: bash
       env:
         TWINE_NON_INTERACTIVE: y
-        FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.TWINE_TOKEN }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ scratch/
 # build outputs
 build/
 dist/
+*.egg-info
 *.pyd
 *.so
 *.dll

--- a/binpickle/__init__.py
+++ b/binpickle/__init__.py
@@ -2,7 +2,15 @@
 Optimized format for pickling binary data.
 """
 
-__version__ = "0.4.0"
+from importlib.metadata import version, PackageNotFoundError
 
-from .write import dump, BinPickler  # noqa: F401
-from .read import load, BinPickleFile  # noqa: F401
+from .write import dump, BinPickler
+from .read import load, BinPickleFile
+
+try:
+    __version__ = version("progress-api")
+except PackageNotFoundError:
+    # package is not installed
+    pass
+
+__all__ = ["dump", "BinPickler", "load", "BinPickleFile"]

--- a/binpickle/__init__.py
+++ b/binpickle/__init__.py
@@ -8,7 +8,7 @@ from .write import dump, BinPickler
 from .read import load, BinPickleFile
 
 try:
-    __version__ = version("progress-api")
+    __version__ = version("binpickle")
 except PackageNotFoundError:
     # package is not installed
     pass

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 import binpickle
 
-project = "BinPickle""
+project = "BinPickle"
 copyright = "2023 Michael Ekstrand"
 author = "Michael D. Ekstrand"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,44 +1,40 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 import binpickle
 
-project = 'BinPickle'
-copyright = '2020-2022 Boise State University'
-author = 'Michael D. Ekstrand'
+project = "BinPickle""
+copyright = "2023 Michael Ekstrand"
+author = "Michael D. Ekstrand"
 
 release = binpickle.__version__
 
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinxext.opengraph",
 ]
 
-source_suffix = '.rst'
+source_suffix = ".rst"
 
-pygments_style = 'sphinx'
-highlight_language = 'python3'
+pygments_style = "sphinx"
+highlight_language = "python3"
 
-html_theme = 'furo'
+html_theme = "furo"
 html_theme_options = {
-    'github_user': 'lenskit',
-    'github_repo': 'binpickle',
-    'travis_button': False,
-    # 'canonical_url': 'https://binpickle.lenskit.org/',
-    # 'font_family': 'Georgia, Charter, serif'
 }
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'numba': ('https://numba.readthedocs.io/en/stable/', None),
-    'numcodecs': ('https://numcodecs.readthedocs.io/en/stable/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
 }
 
 autodoc_default_options = {
-    'members': True,
-    'member-order': 'bysource'
+    "members": True,
+    "member-order": "bysource"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ authors = [
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
   "pytest >= 5",
   "pytest-cov",
   "hypothesis >= 6",
-  "pandas >= 1.0",
+  "pandas >= 1.4",
   "numpy >= 1.17",
 ]
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "binpickle"
+description = "Optimized format for pickling binary data."
 authors = [
   {name="Michael Ekstrand", email="mdekstrand@drexel.edu"}
 ]
@@ -18,16 +19,19 @@ classifiers = [
 ]
 requires-python = ">= 3.10"
 readme = "README.md"
-dynamic = ["version", "description"]
+license = { file = "LICENSE.md" }
+dynamic = ["version"]
 dependencies = [
   "msgpack >= 1.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-  "flit >=3.8",
+  "setuptools>=64",
+  "setuptools_scm>=8",
   "ruff",
   "copier",
+  "sphinx-autobuild",
 ]
 test = [
   "pytest >= 5",
@@ -37,7 +41,8 @@ test = [
   "numpy >= 1.17",
 ]
 doc = [
-  "sphinx >=4",
+  "sphinx >=4.2",
+  "sphinxext-opengraph >= 0.5",
   "furo",
 ]
 blosc = [
@@ -52,15 +57,11 @@ Homepage = "https://binpickle.lenksit.org"
 GitHub = "https://github.com/lenskit/binpickle"
 
 # configure build tools
-[tool.flit.sdist]
-include = ["tests/*"]
-exclude = [
-  ".github"
-]
+[tool.setuptools]
+packages = ["binpickle"]
 
-# need this for the SCM plugins to work
-[tool.setuptools.packages.find]
-exclude = ["envs"]
+[tool.setuptools_scm]
+version_scheme = "release-branch-semver"
 
 # settings for generating conda environments for dev & CI, when needed
 [tool.pyproject2conda]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ test = [
   "pytest-cov",
   "hypothesis >= 6",
   "pandas >= 1.4",
-  "numpy >= 1.17",
+  "numpy >= 1.22",
 ]
 doc = [
   "sphinx >=4.2",


### PR DESCRIPTION
This updates to the latest template & uses Setuptools (closes #27). It also bumps minimum dep versions in accordance with [SPEC0](https://scientific-python.org/specs/spec-0000/), so we require Pandas 1.4 (for tests) and Numpy 1.22 or later.