### PR TITLE
Update to current LensKit repo standards

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,7 @@
 # Changes here will be overwritten by Copier
-_commit: '8259712'
+_commit: f8b65ae
 _src_path: https://github.com/lenskit/lk-project-template
+owner: Drexel University and contributors
 package_name: binpickle
 project_descr: Optimized format for pickling binary data.
 project_name: binpickle

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,61 @@
+name: Package and Publish
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  dist:
+    name: Build Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch Git tags
+        run: git fetch --tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Python deps
+        run: pip install -U build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Save archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-pkgs
+          path: dist
+
+      - name: List dist dir
+        run: ls -R dist
+
+  pypi-publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [dist]
+    if: github.event_name == 'release'
+
+    environment: release
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Fetch compiled package distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-pkgs
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-  release:
-    types: [created,published]
   pull_request:
 
 concurrency:
@@ -63,46 +61,3 @@ jobs:
 
     - name: Report test results
       uses: lenskit/lkbuild/actions/report-test-results@main
-
-  sdist:
-    name: Build Source Packages
-    runs-on: ubuntu-latest
-    needs: [test]
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Fetch Git tags
-      run: git fetch --tags
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-
-    - name: Install Python deps
-      run: pip install -U build twine
-
-    - name: Build distribution
-      run: python -m build
-
-    - name: Save archive
-      uses: actions/upload-artifact@v1
-      with:
-        name: pypi-pkgs
-        path: dist
-
-    - name: List dist dir
-      run: ls -R dist
-
-    - name: Publish PyPI packages
-      if: github.event_name == 'release'
-      run: |
-        twine upload dist/*
-      shell: bash
-      env:
-        TWINE_NON_INTERACTIVE: y
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}

--- a/.header.yaml
+++ b/.header.yaml
@@ -1,0 +1,11 @@
+root: true
+start_year: 2020
+owner: Drexel University and contributors
+substring: This file is part of
+template: |-
+  {comment_start} This file is part of BinPickle.
+  {comment_middle} Copyright (C) {start_year}-2023 Boise State University
+  {comment_middle} Copyright (C) 2023-{end_year} Drexel University
+  {comment_middle} Licensed under the MIT license, see LICENSE.md for details.
+  {comment_middle} SPDX-License-Identifier: MIT
+  {comment_end}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 Copyright (c) 2020–2023 Boise State University
-Copyright (c) 2023 Michael Ekstrand
+Copyright (c) 2023-2024 Drexel University and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+prune envs
+prune .github
+prune .vscode
+exclude .*.yml
+exclude .*.yaml

--- a/binpickle/__init__.py
+++ b/binpickle/__init__.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 """
 Optimized format for pickling binary data.
 """

--- a/binpickle/_util.py
+++ b/binpickle/_util.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 """
 Internal utility functions for Binpickle.
 """

--- a/binpickle/encode.py
+++ b/binpickle/encode.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 """
 Support for encoding and decoding.
 """

--- a/binpickle/errors.py
+++ b/binpickle/errors.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 class BinPickleError(Exception):
     """
     Base class for Binpickle errors.

--- a/binpickle/format.py
+++ b/binpickle/format.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 """
 Constants and functions defining the binpickle format.
 """

--- a/binpickle/read.py
+++ b/binpickle/read.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 import hashlib
 import io
 import logging

--- a/binpickle/write.py
+++ b/binpickle/write.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 import hashlib
 import io
 import logging

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 from hypothesis import settings
 import pytest
 import numpy as np

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath(".."))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
   "ruff",
   "pyright",
   "copier",
+  "unbeheader",         # p2c: -p
   "ipython",
   "pyproject2conda",
   "sphinx-autobuild",

--- a/tests/test_file_info.py
+++ b/tests/test_file_info.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 
 from binpickle import file_info

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 from pytest import raises
 
 from binpickle.errors import FormatError

--- a/tests/test_rw.py
+++ b/tests/test_rw.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 import gc
 import itertools as it
 from pathlib import Path

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 import logging
 
 from hypothesis import given

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 import os
 import logging
 

--- a/typings/numcodecs/__init__.pyi
+++ b/typings/numcodecs/__init__.pyi
@@ -1,2 +1,8 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 from . import abc
 from . import registry

--- a/typings/numcodecs/abc.pyi
+++ b/typings/numcodecs/abc.pyi
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 from abc import ABC
 from typing import Any
 

--- a/typings/numcodecs/registry.pyi
+++ b/typings/numcodecs/registry.pyi
@@ -1,3 +1,9 @@
+# This file is part of BinPickle.
+# Copyright (C) 2020-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 from typing import Any
 
 from .abc import Codec


### PR DESCRIPTION
This updates to the new template and standards:

1. Separate packaging workflow with Trusted Publishers
2. Add copyright headers and update license