### PR TITLE
Add CLI to inspect and verify Binpickle files

### DIFF
--- a/binpickle/__main__.py
+++ b/binpickle/__main__.py
@@ -1,0 +1,7 @@
+"""
+Entry point for Binpickle CLI tool.
+"""
+
+from ._cli import main
+
+main()

--- a/binpickle/__main__.py
+++ b/binpickle/__main__.py
@@ -2,6 +2,8 @@
 Entry point for Binpickle CLI tool.
 """
 
+import sys
+
 from ._cli import main
 
-main()
+sys.exit(main())

--- a/binpickle/_cli.py
+++ b/binpickle/_cli.py
@@ -43,10 +43,11 @@ Print information from a binpickle file.
     return parser.parse_args(args)
 
 
-def init_cli(opts: argparse.Namespace):
+def init_cli(opts: argparse.Namespace, init_log: bool):
     "Initialize CLI environment (logging, etc.)"
     level = logging.DEBUG if opts.verbose else logging.INFO
-    logging.basicConfig(stream=sys.stderr, level=level)
+    if init_log:
+        logging.basicConfig(stream=sys.stderr, level=level)
 
 
 def list_buffers(bpf: BinPickleFile, opts: argparse.Namespace):
@@ -95,13 +96,15 @@ def verify_buffers(bpf: BinPickleFile, opts: argparse.Namespace):
         except IntegrityError as e:
             _log.error("buffer %d invalid: %s", i, e)
             nbad += 1
+        finally:
+            buf.release()
 
     return nbad > 0
 
 
-def main(args: Optional[Sequence[str]] = None):
+def main(args: Optional[Sequence[str]] = None, init_log=False):
     opts = parse_cli(args)
-    init_cli(opts)
+    init_cli(opts, init_log)
 
     _log.info("opening %s", opts.FILE)
     failed = False

--- a/binpickle/_cli.py
+++ b/binpickle/_cli.py
@@ -1,0 +1,94 @@
+# pyright: basic
+"""
+BinPickle CLI internals.
+"""
+import argparse
+import io
+import logging
+import pickletools
+import sys
+from textwrap import dedent
+from typing import Optional, Sequence
+
+import prettytable as pt
+
+from . import BinPickleFile
+from .format import pretty_codec
+
+_log = logging.getLogger(__name__)
+
+
+def parse_cli(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        "binpickle",
+        "python -m binpickle [options] FILE",
+        dedent(
+            """
+Print information from a binpickle file.
+            """
+        ),
+    )
+    parser.add_argument("FILE", help="the Binpickle file to read.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose logging")
+
+    dump = parser.add_argument_group("Dump options")
+    dump.add_argument("-l", "--list", action="store_true", help="list the buffers")
+    dump.add_argument(
+        "-D", "--disassemble", action="store_true", help="disassemble the pickle data"
+    )
+
+    return parser.parse_args(args)
+
+
+def init_cli(opts: argparse.Namespace):
+    "Initialize CLI environment (logging, etc.)"
+    level = logging.DEBUG if opts.verbose else logging.INFO
+    logging.basicConfig(stream=sys.stderr, level=level)
+
+
+def list_buffers(bpf: BinPickleFile, opts: argparse.Namespace):
+    table = pt.PrettyTable()
+    table.field_names = ["#", "Length", "Enc. Len.", "Type", "Shape", "Codec"]
+    table.align = "r"
+    table.align["Type"] = "c"  # pyright: ignore
+    table.align["Shape"] = "c"  # pyright: ignore
+    table.align["Codec"] = "c"  # pyright: ignore
+    table.vrules = pt.NONE
+    for i, entry in enumerate(bpf.entries):
+        row = [i, entry.dec_length, entry.enc_length]
+        if entry.info is None:
+            row += ["", ""]
+        else:
+            at, dt, shape = entry.info
+            ss = ", ".join(str(i) for i in shape)
+            if at != "ndarray":
+                dt = f"{at}[{dt}]"
+            row += [dt, ss]
+
+        row.append(pretty_codec(entry.codecs))
+        table.add_row(row)
+
+    print(table)
+
+
+def disassemble_pickle(bpf: BinPickleFile, opts: argparse.Namespace):
+    buf = bpf._read_buffer(bpf.entries[-1])
+    pickletools.dis(io.BytesIO(buf), sys.stdout)
+
+
+def main(args: Optional[Sequence[str]] = None):
+    opts = parse_cli(args)
+    init_cli(opts)
+
+    _log.info("opening %s", opts.FILE)
+    with BinPickleFile(opts.FILE) as bpf:
+        _log.info("%s: opened file with version %s", opts.FILE, bpf.header.version)
+        _log.info("%s: flags: %d (%s)", opts.FILE, bpf.header.flags._value_, bpf.header.flags)
+        _log.info("%s: length: %d", opts.FILE, bpf.header.length)
+        _log.info("%s: buffers: %d", opts.FILE, len(bpf.entries))
+
+        if opts.list:
+            list_buffers(bpf, opts)
+
+        if opts.disassemble:
+            disassemble_pickle(bpf, opts)

--- a/binpickle/errors.py
+++ b/binpickle/errors.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
+
 class BinPickleError(Exception):
     """
     Base class for Binpickle errors.

--- a/binpickle/format.py
+++ b/binpickle/format.py
@@ -51,7 +51,7 @@ def pretty_codec(codec: CodecSpec | list[CodecSpec] | None) -> str:
         args = ["{}={}".format(k, repr(v)) for (k, v) in codec.items() if k != "id"]
         astr = ", ".join(args)
         return f"{name}({astr})"
-    else:
+    else:  # pragma: no cover
         raise TypeError("invalid codec")
 
 

--- a/binpickle/format.py
+++ b/binpickle/format.py
@@ -35,6 +35,26 @@ HEADER_FORMAT = struct.Struct("!4sHHq")
 TRAILER_FORMAT = struct.Struct("!QL32s")
 
 
+def pretty_codec(codec: CodecSpec | list[CodecSpec] | None) -> str:
+    if codec is None:
+        return "none"
+    elif isinstance(codec, list):
+        if len(codec) == 0:
+            return pretty_codec(None)
+        elif len(codec) == 1:
+            return pretty_codec(codec[0])
+        else:
+            sp = [pretty_codec(c) for c in codec]
+            return "[" + ", ".join(sp) + "]"
+    elif isinstance(codec, dict):
+        name = codec["id"]
+        args = ["{}={}".format(k, repr(v)) for (k, v) in codec.items() if k != "id"]
+        astr = ", ".join(args)
+        return f"{name}({astr})"
+    else:
+        raise TypeError("invalid codec")
+
+
 class Flags(enum.Flag):
     """
     Flags that can be set in the BinPickle header.

--- a/binpickle/read.py
+++ b/binpickle/read.py
@@ -221,8 +221,10 @@ class BinPickleFile:
             _log.debug("copying %d bytes from %d", length, start)
             return buf.tobytes()
 
-    def _verify_buffer(self, buf: memoryview, hash: bytes, msg: str = "buffer"):
-        if self.verify:
+    def _verify_buffer(
+        self, buf: memoryview, hash: bytes, msg: str = "buffer", force: bool = False
+    ):
+        if self.verify or force:
             _log.debug("verifying %s", msg)
             bhash = hash_buffer(buf)
             if bhash != hash:

--- a/binpickle/read.py
+++ b/binpickle/read.py
@@ -77,6 +77,7 @@ class BinPickleFile:
         self.filename = filename
         self.direct = direct
         self.verify = verify
+        _log.debug("opening %s", filename)
         with open(filename, "rb", buffering=0) as bpf:
             self._read_header(bpf)
             self._map = mmap.mmap(bpf.fileno(), self.header.length, access=mmap.ACCESS_READ)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "msgpack >= 1.0",           # p2c: -s msgpack-python
   "numcodecs >= 0.12",
   "typing-extensions ~= 4.8",
+  "prettytable ~= 3.5",
 ]
 
 [project.optional-dependencies]
@@ -35,7 +36,7 @@ dev = [
   "ruff",
   "pyright",
   "copier",
-  "unbeheader",         # p2c: -p
+  "unbeheader",        # p2c: -p
   "ipython",
   "pyproject2conda",
   "sphinx-autobuild",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,11 @@ version_scheme = "guess-next-dev"
 [tool.pyproject2conda]
 channels = ["conda-forge"]
 
+[tool.coverage.report]
+omit = [
+  "binpickle/__main__.py",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,73 @@
+import re
+from os import fspath
+from pathlib import Path
+from typing import Generator
+
+import numpy as np
+import pandas as pd
+
+from pytest import CaptureFixture, LineMatcher, fixture
+
+from binpickle._cli import main
+from binpickle.write import dump
+
+
+def gen_frame(file: Path, rng: np.random.Generator, mappable: bool = False):
+    "Pickle a Pandas data frame"
+
+    df = pd.DataFrame(
+        {
+            "key": np.arange(0, 5000),
+            "count": rng.integers(0, 1000, 5000),
+            "score": rng.normal(10, 2, 5000),
+        }
+    )
+
+    dump(df, file, mappable=mappable)
+
+
+@fixture
+def df_bpf(tmp_path: Path, rng: np.random.Generator) -> Generator[Path, None, None]:
+    file = tmp_path / "data.bpk"
+    gen_frame(file, rng)
+
+    yield file
+
+
+def test_no_opts(df_bpf: Path):
+    rc = main([fspath(df_bpf)], init_log=False)
+    assert rc == 0
+
+
+def test_list(capsys: CaptureFixture[str], df_bpf: Path):
+    capsys.readouterr()
+    rc = main(["-l", fspath(df_bpf)], init_log=False)
+    assert rc == 0
+    out, _err = capsys.readouterr()
+    lm = LineMatcher(out.splitlines())
+    lm.re_match_lines([r"\s+#\s+Offset.*", r"\s+0\s+\d+\s+\d+\s+\d+.*", r"\s+1\s+\d+\s+\d+.*"])
+
+
+def test_disassemble(capsys: CaptureFixture[str], df_bpf: Path):
+    capsys.readouterr()
+    rc = main(["-D", fspath(df_bpf)], init_log=False)
+    assert rc == 0
+    out, _err = capsys.readouterr()
+    lm = LineMatcher(out.splitlines())
+    lm.re_match_lines([r"\s+\d+:\s+\\x\w+\s+PROTO\s+5"])
+
+
+def test_verify(capsys: CaptureFixture[str], df_bpf: Path):
+    rc = main(["-V", fspath(df_bpf)], init_log=False)
+    assert rc == 0
+
+
+def test_verify_fail(capsys: CaptureFixture[str], df_bpf: Path):
+    # corrupt the file
+    with open(df_bpf, "r+b") as f:
+        f.seek(32)
+        f.write(b"\0\0")
+
+    # run verification
+    rc = main(["-V", fspath(df_bpf)], init_log=False)
+    assert rc != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-import re
+# pyright: basic
 from os import fspath
 from pathlib import Path
 from typing import Generator


### PR DESCRIPTION
This adds a small CLI to inspect and verify the contents of a Binpickle file.

It can be run with `python -m binpickle`.