### PR TITLE
Add space in the format for a future MAC

### DIFF
--- a/binpickle/format.py
+++ b/binpickle/format.py
@@ -180,7 +180,7 @@ class FileTrailer:
         """
         off, len, ck, mac = TRAILER_FORMAT.unpack(buf)
         if verify and mac != b"\0" * 32:
-            raise ValueError("nonzero MACs not supported")
+            raise FormatError("nonzero MACs not supported")
         return cls(off, len, ck, mac)
 
 

--- a/binpickle/read.py
+++ b/binpickle/read.py
@@ -170,7 +170,7 @@ class BinPickleFile:
         assert self._mv is not None, "file not open"
 
         buf = self._mv[tpos:]
-        assert len(buf) == 44
+        assert len(buf) == FileTrailer.SIZE
         self.trailer = FileTrailer.decode(buf)
 
         i_start = self.trailer.offset

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -7,14 +7,14 @@
 from pytest import raises
 
 from binpickle.errors import FormatError
-from binpickle.format import FileHeader, FileTrailer, HEADER_FORMAT, TRAILER_FORMAT, Flags
+from binpickle.format import HEADER_FORMAT, TRAILER_FORMAT, FileHeader, FileTrailer, Flags
 
 
 def test_format_sizes():
     assert HEADER_FORMAT.size == 16
     assert FileHeader.SIZE == 16
-    assert TRAILER_FORMAT.size == 44
-    assert FileTrailer.SIZE == 44
+    assert TRAILER_FORMAT.size == 76
+    assert FileTrailer.SIZE == 76
 
 
 def test_pack_default_header():

--- a/tests/test_rw.py
+++ b/tests/test_rw.py
@@ -52,7 +52,7 @@ def test_empty(tmp_path):
     with BinPickler(file) as w:
         w._finish_file()
 
-    assert file.stat().st_size == 61
+    assert file.stat().st_size == 93
 
     with BinPickleFile(file) as bpf:
         assert len(bpf.entries) == 0

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,9 +13,36 @@ import pandas as pd
 import pytest
 
 from binpickle import BinPickleFile, dump
-from binpickle.errors import IntegrityError
+from binpickle.errors import FormatError, IntegrityError
 
 _log = logging.getLogger(__name__)
+
+
+def test_verfy_unsupported_mac(tmp_path, rng: np.random.Generator):
+    "Nonzero MAC should fail"
+    file = tmp_path / "data.bpk"
+
+    df = pd.DataFrame(
+        {
+            "key": np.arange(0, 5000),
+            "count": rng.integers(0, 1000, 5000),
+            "score": rng.normal(10, 2, 5000),
+        }
+    )
+
+    dump(df, file, codecs=["lz4"])
+
+    # corrupt the file
+    stat = os.stat(file)
+    _log.info("%s: length %d", file, stat.st_size)
+    with open(file, "r+b") as f:
+        f.seek(stat.st_size - 4)
+        f.write(b"XX")
+
+    # try to read the file
+    with pytest.raises(FormatError, match=r"nonzero MACs"):
+        with BinPickleFile(file) as _bpf:
+            pass
 
 
 def test_verfy_index(tmp_path, rng: np.random.Generator):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,15 +4,15 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-import os
 import logging
+import os
 
 import numpy as np
 import pandas as pd
 
 import pytest
 
-from binpickle import dump, BinPickleFile
+from binpickle import BinPickleFile, dump
 from binpickle.errors import IntegrityError
 
 _log = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ def test_verfy_index(tmp_path, rng: np.random.Generator):
     stat = os.stat(file)
     _log.info("%s: length %d", file, stat.st_size)
     with open(file, "r+b") as f:
-        f.seek(stat.st_size - 2)
+        f.seek(stat.st_size - 34)
         f.write(b"XX")
 
     # try to read the file


### PR DESCRIPTION
This adds a new field to the file trailer to eventually store a MAC, to enable #55 without requiring incompatible format changes.